### PR TITLE
Bugfix/fix unhandled unexisting icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wtw-icons",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "The best open source icon library with an accessibility focus",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/react/components/WTWIcon.tsx
+++ b/src/react/components/WTWIcon.tsx
@@ -7,6 +7,10 @@ export interface WTWIconProps extends SVGProps<SVGSVGElement> {
 }
 
 const WTWIcon: React.FC<WTWIconProps> = ({ icon, ...props }) => {
+    if (!(icon in iconsObject)) {
+        console.error(`${icon} is not a valid icon!!`);
+        return React.createElement(iconsObject['missing'], props);
+    }
     return React.createElement(iconsObject[icon], props);
 };
 


### PR DESCRIPTION
before this change, if you passed an invalid icon to WTWIcon, it would crash, now it just returns the missing icon and throws an error to the console